### PR TITLE
cd into directories before uploading/downloading

### DIFF
--- a/download
+++ b/download
@@ -22,6 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cd "$LOCAL_PATH" || exit 1
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
 debug;
 set cmd:fail-exit yes;
@@ -46,6 +48,7 @@ set sftp:max-packets-in-flight $SFTP_MAX_PACKETS_IN_FLIGHT;
 set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
-mirror --no-perms $LOCAL_PATH $REMOTE_PATH;
+cd $REMOTE_PATH;
+mirror --no-perms;
 exit;
 EOF

--- a/upload
+++ b/upload
@@ -22,6 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cd "$LOCAL_PATH" || exit 1
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
 debug;
 set cmd:fail-exit yes;
@@ -46,6 +48,7 @@ set sftp:max-packets-in-flight $SFTP_MAX_PACKETS_IN_FLIGHT;
 set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
-mirror --no-perms --delete -R $LOCAL_PATH $REMOTE_PATH
-exit
+cd $REMOTE_PATH;
+mirror --no-perms --delete -R;
+exit;
 EOF


### PR DESCRIPTION
Re-work scripts to `cd` into appropriate working directories and then invoke `mirror` without passing the `source` or `target` args. I.e., just mirror the current directory on the client to the current directory on the server (or vice-versa, in the case of `/download`).

The most important thing this addresses is, from what I can tell, a bug in `lftp` where it attempts to `mkdir` the `$REMOTE_PATH` on upload, but doesn't gracefully handle the (admittedly slightly funky) server telling it it cannot do that. It *also* addresses some funky semantics that `lftp` has around paths that end with `/` when mirroring:

> If the target directory  ends  with  a  slash (except the root directory) then base name of the source directory is appended.

I feel like we're explicitly building a blunt instrument here--"make that directory over there be like this directory over here"--so I'd rather have it not mangle my paths in ways that I cannot reason about without returning to the documentation every single time.

A side effect of this change is that for `/upload` the target directory *must already exist on the server* and for `/download` the target directory *must already exist on the client*.

It is also a little yucky to have a shell script `cd` into a directory but not manage `cd`'ing back out at the end, but I figure this thing is designed to run in single-use docker containers and that it'll be fine.