### PR TITLE
Make debug out put / file deletion toggleable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENV SFTP_MAX_PACKETS_IN_FLIGHT         16
 ENV SFTP_PROTOCOL_VERSION               6
 ENV SFTP_SERVER_PROGRAM              sftp
 
+ADD ./_func    /_func
 ADD ./help     /help
 ADD ./upload   /upload
 ADD ./download /download

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ will be uploaded to the remote server.
 
 The following environment variables are used for configuration:
 
-|     Variable    |             Description             |        Example         |
-|-----------------|-------------------------------------|------------------------|
-| `REMOTE_SERVER` | The URL                             | sftp://ftp.example.com |
-| `USERNAME`      | The username for the remote server. | kentclark              |
-| `PASSWORD`      | The password for the remote server. | superman               |
-| `REMOTE_PATH`   | The remote path                     | /home/kentclark/files  |
-
+|     Variable    |               Description                |        Example         |
+|-----------------|------------------------------------------|------------------------|
+| `REMOTE_SERVER` | The URL                                  | sftp://ftp.example.com |
+| `USERNAME`      | The username for the remote server.      | kentclark              |
+| `PASSWORD`      | The password for the remote server.      | superman               |
+| `REMOTE_PATH`   | The remote path                          | /home/kentclark/files  |
+| `DEBUG`         | Whether to produce verbose debug output. | true                   |
 
 ### Examples
 
@@ -51,6 +51,7 @@ docker run --rm \
            --env USERNAME="kentclark" \
            --env PASSWORD="superman" \
            --env REMOTE_PATH="/remote/path/to/download" \
+           --env DEBUG=true \
            --volume "/local/path/to/save/files":/files \
            toolhouse/lftp:v0.1.0 /download
 ```
@@ -63,6 +64,7 @@ docker run --rm \
            --env USERNAME="kentclark" \
            --env PASSWORD="superman" \
            --env REMOTE_PATH="/remote/to/files" \
+           --env DEBUG=true \
            --volume "/local/path/to/upload/files":/files \
            toolhouse/lftp:v0.1.0 /download
 ```

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ will be uploaded to the remote server.
 
 The following environment variables are used for configuration:
 
-|     Variable    |               Description                |        Example         |
-|-----------------|------------------------------------------|------------------------|
-| `REMOTE_SERVER` | The URL                                  | sftp://ftp.example.com |
-| `USERNAME`      | The username for the remote server.      | kentclark              |
-| `PASSWORD`      | The password for the remote server.      | superman               |
-| `REMOTE_PATH`   | The remote path                          | /home/kentclark/files  |
-| `DEBUG`         | Whether to produce verbose debug output. | true                   |
+|     Variable    |                              Description                               |        Example         |
+|-----------------|------------------------------------------------------------------------|------------------------|
+| `REMOTE_SERVER` | The URL                                                                | sftp://ftp.example.com |
+| `USERNAME`      | The username for the remote server.                                    | kentclark              |
+| `PASSWORD`      | The password for the remote server.                                    | superman               |
+| `REMOTE_PATH`   | The remote path                                                        | /home/kentclark/files  |
+| `DEBUG`         | Whether to produce verbose debug output.                               | true                   |
+| `DELETE_FILES`  | Whether to delete files in destination that are not present in source. | true                       |
 
 ### Examples
 
@@ -52,6 +53,7 @@ docker run --rm \
            --env PASSWORD="superman" \
            --env REMOTE_PATH="/remote/path/to/download" \
            --env DEBUG=true \
+           --env DELETE_FILES=true \
            --volume "/local/path/to/save/files":/files \
            toolhouse/lftp:v0.1.0 /download
 ```
@@ -65,6 +67,7 @@ docker run --rm \
            --env PASSWORD="superman" \
            --env REMOTE_PATH="/remote/to/files" \
            --env DEBUG=true \
+           --env DELETE_FILES=true \
            --volume "/local/path/to/upload/files":/files \
            toolhouse/lftp:v0.1.0 /download
 ```

--- a/_func
+++ b/_func
@@ -1,0 +1,23 @@
+# Copyright 2017 Toolhouse, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Takes an argument at returns whether it looks "truthy"
+parse_bool() {
+    ARG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed s/\\s//)
+    if [ "$ARG" = "" ]; then return 1; fi
+    if [ "$ARG" = "false" ]; then return 1; fi
+    if [ "$ARG" = "no" ]; then return 1; fi
+    if [ "$ARG" = "off" ]; then return 1; fi
+    if [ "$ARG" -eq 0 ] 2> /dev/null; then return 1; fi
+}

--- a/download
+++ b/download
@@ -26,15 +26,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+. /_func
+
 cd "$LOCAL_PATH" || exit 1
 
 DEBUG_STATEMENT=""
-if [ "$DEBUG" != "" ]; then
+if parse_bool "$DEBUG"; then
     DEBUG_STATEMENT=debug;
 fi
 
 DELETE_ARG=""
-if [ "$DELETE_FILES" != "" ]; then
+if parse_bool "$DELETE_FILES"; then
+    echo "Warning: This will delete files at destination that are not present at the source. To disable this behavior, set DELETE_FILES=false"
     DELETE_ARG=--delete
 fi
 

--- a/download
+++ b/download
@@ -22,6 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cd "$LOCAL_PATH" || exit 1
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
 debug;
 set cmd:fail-exit yes;
@@ -46,6 +48,7 @@ set sftp:max-packets-in-flight $SFTP_MAX_PACKETS_IN_FLIGHT;
 set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
-mirror --no-perms $LOCAL_PATH $REMOTE_PATH;
+cd $REMOTE_PATH;
+mirror --no-perms;
 exit;
 EOF

--- a/download
+++ b/download
@@ -7,6 +7,7 @@
 #   - REMOTE_PATH
 #   - USERNAME
 #   - PASSWORD
+#   - DEBUG
 
 # Copyright 2017 Toolhouse, Inc.
 #
@@ -24,8 +25,14 @@
 
 cd "$LOCAL_PATH" || exit 1
 
+DEBUG_STATEMENT=""
+if [ "$DEBUG" != "" ]; then
+    DEBUG_STATEMENT=debug;
+fi
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
-debug;
+$DEBUG_STATEMENT
+
 set cmd:fail-exit yes;
 
 set net:limit-rate $NET_LIMIT_RATE;

--- a/download
+++ b/download
@@ -1,13 +1,16 @@
 #! /bin/sh
 
-# download - resucrively downloads from a server to the local 
+# download - recursively downloads from a server to the local
 # container. The following environment variables are required:
 #   - LOCAL_PATH
 #   - REMOTE_SERVER
 #   - REMOTE_PATH
 #   - USERNAME
 #   - PASSWORD
+#
+# The following environment variables are optional:
 #   - DEBUG
+#   - DELETE_FILES
 
 # Copyright 2017 Toolhouse, Inc.
 #
@@ -28,6 +31,11 @@ cd "$LOCAL_PATH" || exit 1
 DEBUG_STATEMENT=""
 if [ "$DEBUG" != "" ]; then
     DEBUG_STATEMENT=debug;
+fi
+
+DELETE_ARG=""
+if [ "$DELETE_FILES" != "" ]; then
+    DELETE_ARG=--delete
 fi
 
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
@@ -56,6 +64,6 @@ set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
 cd $REMOTE_PATH;
-mirror --no-perms;
+mirror --no-perms $DELETE_ARG;
 exit;
 EOF

--- a/upload
+++ b/upload
@@ -26,15 +26,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+. /_func
+
 cd "$LOCAL_PATH" || exit 1
 
 DEBUG_STATEMENT=""
-if [ "$DEBUG" != "" ]; then
+if parse_bool "$DEBUG"; then
     DEBUG_STATEMENT=debug;
 fi
 
 DELETE_ARG=""
-if [ "$DELETE_FILES" != "" ]; then
+if parse_bool "$DELETE_FILES"; then
+    echo "Warning: This will delete files at destination that are not present at the source. To disable this behavior, set DELETE_FILES=false"
     DELETE_ARG=--delete
 fi
 

--- a/upload
+++ b/upload
@@ -22,6 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cd "$LOCAL_PATH" || exit 1
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
 debug;
 set cmd:fail-exit yes;
@@ -46,6 +48,7 @@ set sftp:max-packets-in-flight $SFTP_MAX_PACKETS_IN_FLIGHT;
 set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
-mirror --no-perms --delete -R $LOCAL_PATH $REMOTE_PATH
-exit
+cd $REMOTE_PATH;
+mirror --no-perms --delete -R;
+exit;
 EOF

--- a/upload
+++ b/upload
@@ -56,6 +56,6 @@ set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
 cd $REMOTE_PATH;
-mirror --no-perms --delete -R;
+mirror --no-perms --delete --reverse;
 exit;
 EOF

--- a/upload
+++ b/upload
@@ -7,6 +7,7 @@
 #   - REMOTE_PATH
 #   - USERNAME
 #   - PASSWORD
+#   - DEBUG
 
 # Copyright 2017 Toolhouse, Inc.
 #
@@ -24,8 +25,14 @@
 
 cd "$LOCAL_PATH" || exit 1
 
+DEBUG_STATEMENT=""
+if [ "$DEBUG" != "" ]; then
+    DEBUG_STATEMENT=debug;
+fi
+
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
-debug;
+$DEBUG_STATEMENT
+
 set cmd:fail-exit yes;
 
 set net:limit-rate $NET_LIMIT_RATE;

--- a/upload
+++ b/upload
@@ -1,13 +1,16 @@
 #! /bin/sh
 
-# upload - resucrively uploads file(s) to a remote server. The 
+# upload - recursively uploads file(s) to a remote server. The
 # following environment variables are required:
 #   - LOCAL_PATH
 #   - REMOTE_SERVER
 #   - REMOTE_PATH
 #   - USERNAME
 #   - PASSWORD
+#
+# The following environment variables are optional:
 #   - DEBUG
+#   - DELETE_FILES
 
 # Copyright 2017 Toolhouse, Inc.
 #
@@ -28,6 +31,11 @@ cd "$LOCAL_PATH" || exit 1
 DEBUG_STATEMENT=""
 if [ "$DEBUG" != "" ]; then
     DEBUG_STATEMENT=debug;
+fi
+
+DELETE_ARG=""
+if [ "$DELETE_FILES" != "" ]; then
+    DELETE_ARG=--delete
 fi
 
 lftp -u "$USERNAME","$PASSWORD" $REMOTE_SERVER <<EOF
@@ -56,6 +64,6 @@ set sftp:protocol-version $SFTP_PROTOCOL_VERSION;
 set sftp:server-program $SFTP_SERVER_PROGRAM;
 
 cd $REMOTE_PATH;
-mirror --no-perms --delete --reverse;
+mirror --no-perms $DELETE_ARG --reverse;
 exit;
 EOF


### PR DESCRIPTION
(This is currently based on #1, which should get merged before this.)

This PR:

- Turns off debug output by default (and allows turning back on via `DEBUG=true` environment variable)
- Turns off deletion of missing files by default (and allow turning back on via `DELETE_FILES=true` environment variable)
